### PR TITLE
Modernize: replace macros with inline functions

### DIFF
--- a/triangle.cpp
+++ b/triangle.cpp
@@ -1098,7 +1098,7 @@ int minus1mod3[3] = {2, 0, 1};
 /*   triangle is being deleted entirely, or bonded to another triangle, so   */
 /*   it doesn't matter.                                                      */
 
-#define dissolve(otri)                                                        \
+#define dissolve(m, otri)                                                        \
   (otri).tri[(otri).orient] = (triangle) m->dummytri
 
 /* Copy an oriented triangle.                                                */
@@ -1131,17 +1131,17 @@ int minus1mod3[3] = {2, 0, 1};
 
 /* Check or set a triangle's attributes.                                     */
 
-#define elemattribute(otri, attnum)                                           \
+#define elemattribute(m, otri, attnum)                                        \
   ((REAL *) (otri).tri)[m->elemattribindex + (attnum)]
 
-#define setelemattribute(otri, attnum, value)                                 \
+#define setelemattribute(m, otri, attnum, value)                              \
   ((REAL *) (otri).tri)[m->elemattribindex + (attnum)] = value
 
 /* Check or set a triangle's maximum area bound.                             */
 
-#define areabound(otri)  ((REAL *) (otri).tri)[m->areaboundindex]
+#define areabound(m, otri)  ((REAL *) (otri).tri)[m->areaboundindex]
 
-#define setareabound(otri, value)                                             \
+#define setareabound(m, otri, value)                                          \
   ((REAL *) (otri).tri)[m->areaboundindex] = value
 
 /* Check or set a triangle's deallocation.  Its second pointer is set to     */
@@ -1252,7 +1252,7 @@ int minus1mod3[3] = {2, 0, 1};
 /* Dissolve a subsegment bond (from one side).  Note that the other          */
 /*   subsegment will still think it's connected to this subsegment.          */
 
-#define sdissolve(osub)                                                       \
+#define sdissolve(m, osub)                                                       \
   (osub).ss[(osub).ssorient] = (subseg) m->dummysub
 
 /* Copy a subsegment.                                                        */
@@ -1303,31 +1303,31 @@ int minus1mod3[3] = {2, 0, 1};
 
 /* Dissolve a bond (from the triangle side).                                 */
 
-#define tsdissolve(otri)                                                      \
+#define tsdissolve(m, otri)                                                      \
   (otri).tri[6 + (otri).orient] = (triangle) m->dummysub
 
 /* Dissolve a bond (from the subsegment side).                               */
 
-#define stdissolve(osub)                                                      \
+#define stdissolve(m, osub)                                                      \
   (osub).ss[6 + (osub).ssorient] = (subseg) m->dummytri
 
 /********* Primitives for vertices                                   *********/
 /*                                                                           */
 /*                                                                           */
 
-#define vertexmark(vx)  ((int *) (vx))[m->vertexmarkindex]
+#define vertexmark(m, vx)  ((int *) (vx))[m->vertexmarkindex]
 
-#define setvertexmark(vx, value)                                              \
+#define setvertexmark(m, vx, value)                                              \
   ((int *) (vx))[m->vertexmarkindex] = value
 
-#define vertextype(vx)  ((int *) (vx))[m->vertexmarkindex + 1]
+#define vertextype(m, vx)  ((int *) (vx))[m->vertexmarkindex + 1]
 
-#define setvertextype(vx, value)                                              \
+#define setvertextype(m, vx, value)                                              \
   ((int *) (vx))[m->vertexmarkindex + 1] = value
 
-#define vertex2tri(vx)  ((triangle *) (vx))[m->vertex2triindex]
+#define vertex2tri(m, vx)  ((triangle *) (vx))[m->vertex2triindex]
 
-#define setvertex2tri(vx, value)                                              \
+#define setvertex2tri(m, vx, value)                                              \
   ((triangle *) (vx))[m->vertex2triindex] = value
 
 /**                                                                         **/
@@ -3747,7 +3747,7 @@ struct otri *t;
   }
 
   if (b->vararea) {
-    printf("    Area constraint:  %.4g\n", areabound(*t));
+    printf("    Area constraint:  %.4g\n", areabound(m, *t));
   }
 }
 
@@ -4485,7 +4485,7 @@ vertex dyingvertex;
 {
   /* Mark the vertex as dead.  This makes it possible to detect dead */
   /*   vertices when traversing the list of all vertices.            */
-  setvertextype(dyingvertex, DEADVERTEX);
+  setvertextype(m, dyingvertex, DEADVERTEX);
   pooldealloc(&m->vertices, (VOID *) dyingvertex);
 }
 
@@ -4510,7 +4510,7 @@ struct mesh *m;
     if (newvertex == (vertex) NULL) {
       return (vertex) NULL;
     }
-  } while (vertextype(newvertex) == DEADVERTEX);          /* Skip dead ones. */
+  } while (vertextype(m, newvertex) == DEADVERTEX);          /* Skip dead ones. */
   return newvertex;
 }
 
@@ -4692,10 +4692,10 @@ struct otri *newotri;
     newotri->tri[8] = (triangle) m->dummysub;
   }
   for (i = 0; i < m->eextras; i++) {
-    setelemattribute(*newotri, i, 0.0);
+    setelemattribute(m, *newotri, i, 0.0);
   }
   if (b->vararea) {
-    setareabound(*newotri, -1.0);
+    setareabound(m, *newotri, -1.0);
   }
 
   newotri->orient = 0;
@@ -7307,8 +7307,8 @@ struct otri *testtri;
     }
 
     /* Nonpositive area constraints are treated as unconstrained. */
-    if ((b->vararea) && (area > areabound(*testtri)) &&
-        (areabound(*testtri) > 0.0)) {
+    if ((b->vararea) && (area > areabound(m, *testtri)) &&
+        (areabound(m, *testtri) > 0.0)) {
       /* Add this triangle to the list of bad triangles. */
       enqueuebadtri(m, b, testtri, minedge, tapex, torg, tdest);
       return;
@@ -7334,8 +7334,8 @@ struct otri *testtri;
     /*   both lie in segment interiors, equidistant from the apex where    */
     /*   the two segments meet.                                            */
     /* First, check if both points lie in segment interiors.               */
-    if ((vertextype(base1) == SEGMENTVERTEX) &&
-        (vertextype(base2) == SEGMENTVERTEX)) {
+    if ((vertextype(m, base1) == SEGMENTVERTEX) &&
+        (vertextype(m, base2) == SEGMENTVERTEX)) {
       /* Check if both points lie in a common segment.  If they do, the */
       /*   skinny triangle is enqueued to be split as usual.            */
       tspivot(tri1, testsub);
@@ -7431,7 +7431,7 @@ struct behavior *b;
     for (triangleloop.orient = 0; triangleloop.orient < 3;
          triangleloop.orient++) {
       org(triangleloop, triorg);
-      setvertex2tri(triorg, encode(triangleloop));
+      setvertex2tri(m, triorg, encode(triangleloop));
     }
     triangleloop.tri = triangletraverse(m);
   }
@@ -7840,11 +7840,11 @@ int subsegmark;                            /* Marker for the new subsegment. */
   org(*tri, triorg);
   dest(*tri, tridest);
   /* Mark vertices if possible. */
-  if (vertexmark(triorg) == 0) {
-    setvertexmark(triorg, subsegmark);
+  if (vertexmark(m, triorg) == 0) {
+    setvertexmark(m, triorg, subsegmark);
   }
-  if (vertexmark(tridest) == 0) {
-    setvertexmark(tridest, subsegmark);
+  if (vertexmark(m, tridest) == 0) {
+    setvertexmark(m, tridest, subsegmark);
   }
   /* Check if there's already a subsegment here. */
   tspivot(*tri, newsubseg);
@@ -7989,22 +7989,22 @@ struct otri *flipedge;                    /* Handle for the triangle abc. */
     tspivot(botright, botrsubseg);
     tspivot(topright, toprsubseg);
     if (toplsubseg.ss == m->dummysub) {
-      tsdissolve(topright);
+      tsdissolve(m, topright);
     } else {
       tsbond(topright, toplsubseg);
     }
     if (botlsubseg.ss == m->dummysub) {
-      tsdissolve(topleft);
+      tsdissolve(m, topleft);
     } else {
       tsbond(topleft, botlsubseg);
     }
     if (botrsubseg.ss == m->dummysub) {
-      tsdissolve(botleft);
+      tsdissolve(m, botleft);
     } else {
       tsbond(botleft, botrsubseg);
     }
     if (toprsubseg.ss == m->dummysub) {
-      tsdissolve(botright);
+      tsdissolve(m, botright);
     } else {
       tsbond(botright, toprsubseg);
     }
@@ -8124,22 +8124,22 @@ struct otri *flipedge;                    /* Handle for the triangle abc. */
     tspivot(botright, botrsubseg);
     tspivot(topright, toprsubseg);
     if (toplsubseg.ss == m->dummysub) {
-      tsdissolve(botleft);
+      tsdissolve(m, botleft);
     } else {
       tsbond(botleft, toplsubseg);
     }
     if (botlsubseg.ss == m->dummysub) {
-      tsdissolve(botright);
+      tsdissolve(m, botright);
     } else {
       tsbond(botright, botlsubseg);
     }
     if (botrsubseg.ss == m->dummysub) {
-      tsdissolve(topright);
+      tsdissolve(m, topright);
     } else {
       tsbond(topright, botrsubseg);
     }
     if (toprsubseg.ss == m->dummysub) {
-      tsdissolve(topleft);
+      tsdissolve(m, topleft);
     } else {
       tsbond(topleft, toprsubseg);
     }
@@ -8353,11 +8353,11 @@ int triflaws;
     setorg(horiz, newvertex);
     for (i = 0; i < m->eextras; i++) {
       /* Set the element attributes of a new triangle. */
-      setelemattribute(newbotright, i, elemattribute(botright, i));
+      setelemattribute(m, newbotright, i, elemattribute(m, botright, i));
     }
     if (b->vararea) {
       /* Set the area constraint of a new triangle. */
-      setareabound(newbotright, areabound(botright));
+      setareabound(m, newbotright, areabound(m, botright));
     }
     if (mirrorflag) {
       dest(topright, topvertex);
@@ -8367,11 +8367,11 @@ int triflaws;
       setorg(topright, newvertex);
       for (i = 0; i < m->eextras; i++) {
         /* Set the element attributes of another new triangle. */
-        setelemattribute(newtopright, i, elemattribute(topright, i));
+        setelemattribute(m, newtopright, i, elemattribute(m, topright, i));
       }
       if (b->vararea) {
         /* Set the area constraint of another new triangle. */
-        setareabound(newtopright, areabound(topright));
+        setareabound(m, newtopright, areabound(m, topright));
       }
     }
 
@@ -8380,13 +8380,13 @@ int triflaws;
     if (m->checksegments) {
       tspivot(botright, botrsubseg);
       if (botrsubseg.ss != m->dummysub) {
-        tsdissolve(botright);
+        tsdissolve(m, botright);
         tsbond(newbotright, botrsubseg);
       }
       if (mirrorflag) {
         tspivot(topright, toprsubseg);
         if (toprsubseg.ss != m->dummysub) {
-          tsdissolve(topright);
+          tsdissolve(m, topright);
           tsbond(newtopright, toprsubseg);
         }
       }
@@ -8422,8 +8422,8 @@ int triflaws;
       ssymself(*splitseg);
       /* Transfer the subsegment's boundary marker to the vertex */
       /*   if required.                                          */
-      if (vertexmark(newvertex) == 0) {
-        setvertexmark(newvertex, mark(*splitseg));
+      if (vertexmark(m, newvertex) == 0) {
+        setvertexmark(m, newvertex, mark(*splitseg));
       }
     }
 
@@ -8505,15 +8505,15 @@ int triflaws;
     setapex(horiz, newvertex);
     for (i = 0; i < m->eextras; i++) {
       /* Set the element attributes of the new triangles. */
-      attrib = elemattribute(horiz, i);
-      setelemattribute(newbotleft, i, attrib);
-      setelemattribute(newbotright, i, attrib);
+      attrib = elemattribute(m, horiz, i);
+      setelemattribute(m, newbotleft, i, attrib);
+      setelemattribute(m, newbotright, i, attrib);
     }
     if (b->vararea) {
       /* Set the area constraint of the new triangles. */
-      area = areabound(horiz);
-      setareabound(newbotleft, area);
-      setareabound(newbotright, area);
+      area = areabound(m, horiz);
+      setareabound(m, newbotleft, area);
+      setareabound(m, newbotright, area);
     }
 
     /* There may be subsegments that need to be bonded */
@@ -8521,12 +8521,12 @@ int triflaws;
     if (m->checksegments) {
       tspivot(botleft, botlsubseg);
       if (botlsubseg.ss != m->dummysub) {
-        tsdissolve(botleft);
+        tsdissolve(m, botleft);
         tsbond(newbotleft, botlsubseg);
       }
       tspivot(botright, botrsubseg);
       if (botrsubseg.ss != m->dummysub) {
-        tsdissolve(botright);
+        tsdissolve(m, botright);
         tsbond(newbotright, botrsubseg);
       }
     }
@@ -8675,22 +8675,22 @@ int triflaws;
             tspivot(botright, botrsubseg);
             tspivot(topright, toprsubseg);
             if (toplsubseg.ss == m->dummysub) {
-              tsdissolve(topright);
+              tsdissolve(m, topright);
             } else {
               tsbond(topright, toplsubseg);
             }
             if (botlsubseg.ss == m->dummysub) {
-              tsdissolve(topleft);
+              tsdissolve(m, topleft);
             } else {
               tsbond(topleft, botlsubseg);
             }
             if (botrsubseg.ss == m->dummysub) {
-              tsdissolve(botleft);
+              tsdissolve(m, botleft);
             } else {
               tsbond(botleft, botrsubseg);
             }
             if (toprsubseg.ss == m->dummysub) {
-              tsdissolve(botright);
+              tsdissolve(m, botright);
             } else {
               tsbond(botright, toprsubseg);
             }
@@ -8704,21 +8704,21 @@ int triflaws;
           setapex(top, leftvertex);
           for (i = 0; i < m->eextras; i++) {
             /* Take the average of the two triangles' attributes. */
-            attrib = 0.5 * (elemattribute(top, i) + elemattribute(horiz, i));
-            setelemattribute(top, i, attrib);
-            setelemattribute(horiz, i, attrib);
+            attrib = 0.5 * (elemattribute(m, top, i) + elemattribute(m, horiz, i));
+            setelemattribute(m, top, i, attrib);
+            setelemattribute(m, horiz, i, attrib);
           }
           if (b->vararea) {
-            if ((areabound(top) <= 0.0) || (areabound(horiz) <= 0.0)) {
+            if ((areabound(m, top) <= 0.0) || (areabound(m, horiz) <= 0.0)) {
               area = -1.0;
             } else {
               /* Take the average of the two triangles' area constraints.    */
               /*   This prevents small area constraints from migrating a     */
               /*   long, long way from their original location due to flips. */
-              area = 0.5 * (areabound(top) + areabound(horiz));
+              area = 0.5 * (areabound(m, top) + areabound(m, horiz));
             }
-            setareabound(top, area);
-            setareabound(horiz, area);
+            setareabound(m, top, area);
+            setareabound(m, horiz, area);
           }
 
           if (m->checkquality) {
@@ -9958,13 +9958,13 @@ struct otri *startghost;
       /* Watch out for the case where all the input vertices are collinear. */
       if (dissolveedge.tri != m->dummytri) {
         org(dissolveedge, markorg);
-        if (vertexmark(markorg) == 0) {
-          setvertexmark(markorg, 1);
+        if (vertexmark(m, markorg) == 0) {
+          setvertexmark(m, markorg, 1);
         }
       }
     }
     /* Remove a bounding triangle from a convex hull triangle. */
-    dissolve(dissolveedge);
+    dissolve(m, dissolveedge);
     /* Find the next bounding triangle. */
     sym(deadtriangle, dissolveedge);
     /* Delete the bounding triangle. */
@@ -10019,7 +10019,7 @@ struct behavior *b;
 "Warning:  A duplicate vertex at (%.12g, %.12g) appeared and was ignored.\n",
                sortarray[j][0], sortarray[j][1]);
       }
-      setvertextype(sortarray[j], UNDEADVERTEX);
+      setvertextype(m, sortarray[j], UNDEADVERTEX);
       m->undeads++;
     } else {
       i++;
@@ -10192,17 +10192,17 @@ struct behavior *b;
     if (!b->poly) {
       /* Be careful!  One must check for the case where all the input     */
       /*   vertices are collinear, and thus all the triangles are part of */
-      /*   the bounding box.  Otherwise, the setvertexmark() call below   */
+      /*   the bounding box.  Otherwise, the setvertexmark(m, ) call below   */
       /*   will cause a bad pointer reference.                            */
       if (dissolveedge.tri != m->dummytri) {
         org(dissolveedge, markorg);
-        if (vertexmark(markorg) == 0) {
-          setvertexmark(markorg, 1);
+        if (vertexmark(m, markorg) == 0) {
+          setvertexmark(m, markorg, 1);
         }
       }
     }
     /* Disconnect the bounding box triangle from the mesh triangle. */
-    dissolve(dissolveedge);
+    dissolve(m, dissolveedge);
     lnext(nextedge, deadtriangle);
     sym(deadtriangle, nextedge);
     /* Get rid of the bounding box triangle. */
@@ -10263,7 +10263,7 @@ struct behavior *b;
 "Warning:  A duplicate vertex at (%.12g, %.12g) appeared and was ignored.\n",
                vertexloop[0], vertexloop[1]);
       }
-      setvertextype(vertexloop, UNDEADVERTEX);
+      setvertextype(m, vertexloop, UNDEADVERTEX);
       m->undeads++;
     }
     vertexloop = vertextraverse(m);
@@ -10872,7 +10872,7 @@ struct behavior *b;
 "Warning:  A duplicate vertex at (%.12g, %.12g) appeared and was ignored.\n",
                secondvertex[0], secondvertex[1]);
       }
-      setvertextype(secondvertex, UNDEADVERTEX);
+      setvertextype(m, secondvertex, UNDEADVERTEX);
       m->undeads++;
     }
   } while ((firstvertex[0] == secondvertex[0]) &&
@@ -10921,7 +10921,7 @@ struct behavior *b;
 "Warning:  A duplicate vertex at (%.12g, %.12g) appeared and was ignored.\n",
                  nextvertex[0], nextvertex[1]);
         }
-        setvertextype(nextvertex, UNDEADVERTEX);
+        setvertextype(m, nextvertex, UNDEADVERTEX);
         m->undeads++;
         check4events = 0;
       } else {
@@ -11347,7 +11347,7 @@ FILE *polyfile;
             (killvertexindex < b->firstnumber + m->invertices)) {
           /* Delete the non-corner vertex if it's not already deleted. */
           killvertex = getvertex(m, b, killvertexindex);
-          if (vertextype(killvertex) != DEADVERTEX) {
+          if (vertextype(m, killvertex) != DEADVERTEX) {
             vertexdealloc(m, killvertex);
           }
         }
@@ -11359,13 +11359,13 @@ FILE *polyfile;
     /* Read the triangle's attributes. */
     for (j = 0; j < m->eextras; j++) {
 #ifdef TRILIBRARY
-      setelemattribute(triangleloop, j, triangleattriblist[attribindex++]);
+      setelemattribute(m, triangleloop, j, triangleattriblist[attribindex++]);
 #else /* not TRILIBRARY */
       stringptr = findfield(stringptr);
       if (*stringptr == '\0') {
-        setelemattribute(triangleloop, j, 0);
+        setelemattribute(m, triangleloop, j, 0);
       } else {
-        setelemattribute(triangleloop, j,
+        setelemattribute(m, triangleloop, j,
                          (REAL) strtod(stringptr, &stringptr));
       }
 #endif /* not TRILIBRARY */
@@ -11384,7 +11384,7 @@ FILE *polyfile;
         area = (REAL) strtod(stringptr, &stringptr);
       }
 #endif /* not TRILIBRARY */
-      setareabound(triangleloop, area);
+      setareabound(m, triangleloop, area);
     }
 
     /* Set the triangle's vertices. */
@@ -11563,7 +11563,7 @@ FILE *polyfile;
       /*   information gets overwritten.                 */
       nexttri = checktri.tri[6 + checktri.orient];
       /* No adjacent subsegment.  (This overwrites the stack info.) */
-      tsdissolve(checktri);
+      tsdissolve(m, checktri);
       sym(checktri, checkneighbor);
       if (checkneighbor.tri == m->dummytri) {
         insertsubseg(m, b, &checktri, 1);
@@ -11772,8 +11772,8 @@ vertex endpoint2;
   for (i = 0; i < 2 + m->nextras; i++) {
     newvertex[i] = torg[i] + split * (tdest[i] - torg[i]);
   }
-  setvertexmark(newvertex, mark(*splitsubseg));
-  setvertextype(newvertex, INPUTVERTEX);
+  setvertexmark(m, newvertex, mark(*splitsubseg));
+  setvertextype(m, newvertex, INPUTVERTEX);
   if (b->verbose > 1) {
     printf(
   "  Splitting subsegment (%.12g, %.12g) (%.12g, %.12g) at (%.12g, %.12g).\n",
@@ -11787,7 +11787,7 @@ vertex endpoint2;
     internalerror();
   }
   /* Record a triangle whose origin is the new vertex. */
-  setvertex2tri(newvertex, encode(*splittri));
+  setvertex2tri(m, newvertex, encode(*splittri));
   if (m->steinerleft > 0) {
     m->steinerleft--;
   }
@@ -11795,8 +11795,8 @@ vertex endpoint2;
   /* Divide the segment into two, and correct the segment endpoints. */
   ssymself(*splitsubseg);
   spivot(*splitsubseg, opposubseg);
-  sdissolve(*splitsubseg);
-  sdissolve(opposubseg);
+  sdissolve(m, *splitsubseg);
+  sdissolve(m, opposubseg);
   do {
     setsegorg(*splitsubseg, newvertex);
     snextself(*splitsubseg);
@@ -11962,8 +11962,8 @@ int newmark;
   for (i = 0; i < 2 + m->nextras; i++) {
     newvertex[i] = 0.5 * (endpoint1[i] + endpoint2[i]);
   }
-  setvertexmark(newvertex, newmark);
-  setvertextype(newvertex, SEGMENTVERTEX);
+  setvertexmark(m, newvertex, newmark);
+  setvertextype(m, newvertex, SEGMENTVERTEX);
   /* No known triangle to search from. */
   searchtri1.tri = m->dummytri;
   /* Attempt to insert the new vertex. */
@@ -12307,7 +12307,7 @@ int newmark;
 
   /* Find a triangle whose origin is the segment's first endpoint. */
   checkvertex = (vertex) NULL;
-  encodedtri = vertex2tri(endpoint1);
+  encodedtri = vertex2tri(m, endpoint1);
   if (encodedtri != (triangle) NULL) {
     decode(encodedtri, searchtri1);
     org(searchtri1, checkvertex);
@@ -12340,7 +12340,7 @@ int newmark;
 
   /* Find a triangle whose origin is the segment's second endpoint. */
   checkvertex = (vertex) NULL;
-  encodedtri = vertex2tri(endpoint2);
+  encodedtri = vertex2tri(m, endpoint2);
   if (encodedtri != (triangle) NULL) {
     decode(encodedtri, searchtri2);
     org(searchtri2, checkvertex);
@@ -12653,11 +12653,11 @@ struct behavior *b;
           setmark(hullsubseg, 1);
           org(hulltri, horg);
           dest(hulltri, hdest);
-          if (vertexmark(horg) == 0) {
-            setvertexmark(horg, 1);
+          if (vertexmark(m, horg) == 0) {
+            setvertexmark(m, horg, 1);
           }
-          if (vertexmark(hdest) == 0) {
-            setvertexmark(hdest, 1);
+          if (vertexmark(m, hdest) == 0) {
+            setvertexmark(m, hdest, 1);
           }
         }
       }
@@ -12752,7 +12752,7 @@ struct behavior *b;
             /* Make sure the subsegment doesn't get deallocated again */
             /*   later when the infected neighbor is visited.         */
             uninfect(neighbor);
-            tsdissolve(neighbor);
+            tsdissolve(m, neighbor);
             infect(neighbor);
           }
         }
@@ -12775,18 +12775,18 @@ struct behavior *b;
           *deadtriangle = neighbor.tri;
         } else {               /* The neighbor is protected by a subsegment. */
           /* Remove this triangle from the subsegment. */
-          stdissolve(neighborsubseg);
+          stdissolve(m, neighborsubseg);
           /* The subsegment becomes a boundary.  Set markers accordingly. */
           if (mark(neighborsubseg) == 0) {
             setmark(neighborsubseg, 1);
           }
           org(neighbor, norg);
           dest(neighbor, ndest);
-          if (vertexmark(norg) == 0) {
-            setvertexmark(norg, 1);
+          if (vertexmark(m, norg) == 0) {
+            setvertexmark(m, norg, 1);
           }
-          if (vertexmark(ndest) == 0) {
-            setvertexmark(ndest, 1);
+          if (vertexmark(m, ndest) == 0) {
+            setvertexmark(m, ndest, 1);
           }
         }
       }
@@ -12853,7 +12853,7 @@ struct behavior *b;
             printf("    Deleting vertex (%.12g, %.12g)\n",
                    testvertex[0], testvertex[1]);
           }
-          setvertextype(testvertex, UNDEADVERTEX);
+          setvertextype(m, testvertex, UNDEADVERTEX);
           m->undeads++;
         }
       }
@@ -12870,7 +12870,7 @@ struct behavior *b;
         m->hullsize--;
       } else {
         /* Disconnect the triangle from its neighbor. */
-        dissolve(neighbor);
+        dissolve(m, neighbor);
         /* There is a neighboring triangle on this edge, so this edge */
         /*   becomes a boundary edge when this triangle is deleted.   */
         m->hullsize++;
@@ -12937,11 +12937,11 @@ REAL area;
     uninfect(testtri);
     if (b->regionattrib) {
       /* Set an attribute. */
-      setelemattribute(testtri, m->eextras, attribute);
+      setelemattribute(m, testtri, m->eextras, attribute);
     }
     if (b->vararea) {
       /* Set an area constraint. */
-      setareabound(testtri, area);
+      setareabound(m, testtri, area);
     }
     if (b->verbose > 2) {
       /* Assign the triangle an orientation for convenience in */
@@ -13155,7 +13155,7 @@ int regions;
       triangleloop.orient = 0;
       triangleloop.tri = triangletraverse(m);
       while (triangleloop.tri != (triangle *) NULL) {
-        setelemattribute(triangleloop, m->eextras, 0.0);
+        setelemattribute(m, triangleloop, m->eextras, 0.0);
         triangleloop.tri = triangletraverse(m);
       }
     }
@@ -13339,7 +13339,7 @@ int triflaws;
         /*   subsegment's diametral circle.                        */
         if (!b->conformdel && !acuteorg && !acutedest) {
           apex(enctri, eapex);
-          while ((vertextype(eapex) == FREEVERTEX) &&
+          while ((vertextype(m, eapex) == FREEVERTEX) &&
                  ((eorg[0] - eapex[0]) * (edest[0] - eapex[0]) +
                   (eorg[1] - eapex[1]) * (edest[1] - eapex[1]) < 0.0)) {
             deletevertex(m, b, &testtri);
@@ -13367,7 +13367,7 @@ int triflaws;
           /* Delete free vertices from the subsegment's diametral circle. */
           if (!b->conformdel && !acuteorg2 && !acutedest2) {
             org(testtri, eapex);
-            while ((vertextype(eapex) == FREEVERTEX) &&
+            while ((vertextype(m, eapex) == FREEVERTEX) &&
                    ((eorg[0] - eapex[0]) * (edest[0] - eapex[0]) +
                     (eorg[1] - eapex[1]) * (edest[1] - eapex[1]) < 0.0)) {
               deletevertex(m, b, &testtri);
@@ -13427,8 +13427,8 @@ int triflaws;
           }
         }
 
-        setvertexmark(newvertex, mark(currentenc));
-        setvertextype(newvertex, SEGMENTVERTEX);
+        setvertexmark(m, newvertex, mark(currentenc));
+        setvertextype(m, newvertex, SEGMENTVERTEX);
         if (b->verbose > 1) {
           printf(
   "  Splitting subsegment (%.12g, %.12g) (%.12g, %.12g) at (%.12g, %.12g).\n",
@@ -13573,8 +13573,8 @@ struct badtriang *badtri;
       }
       /* The new vertex must be in the interior, and therefore is a */
       /*   free vertex with a marker of zero.                       */
-      setvertexmark(newvertex, 0);
-      setvertextype(newvertex, FREEVERTEX);
+      setvertexmark(m, newvertex, 0);
+      setvertextype(m, newvertex, FREEVERTEX);
 
       /* Ensure that the handle `badotri' does not represent the longest  */
       /*   edge of the triangle.  This ensures that the circumcenter must */
@@ -13793,15 +13793,15 @@ struct behavior *b;
         }
         /* Set the new node's marker to zero or one, depending on */
         /*   whether it lies on a boundary.                       */
-        setvertexmark(newvertex, trisym.tri == m->dummytri);
-        setvertextype(newvertex,
+        setvertexmark(m, newvertex, trisym.tri == m->dummytri);
+        setvertextype(m, newvertex,
                       trisym.tri == m->dummytri ? FREEVERTEX : SEGMENTVERTEX);
         if (b->usesegments) {
           tspivot(triangleloop, checkmark);
           /* If this edge is a segment, transfer the marker to the new node. */
           if (checkmark.ss != m->dummysub) {
-            setvertexmark(newvertex, mark(checkmark));
-            setvertextype(newvertex, SEGMENTVERTEX);
+            setvertexmark(m, newvertex, mark(checkmark));
+            setvertextype(m, newvertex, SEGMENTVERTEX);
           }
         }
         if (b->verbose > 1) {
@@ -14076,16 +14076,16 @@ FILE **polyfile;
       /* Read a vertex marker. */
       stringptr = findfield(stringptr);
       if (*stringptr == '\0') {
-        setvertexmark(vertexloop, 0);
+        setvertexmark(m, vertexloop, 0);
       } else {
         currentmarker = (int) strtol(stringptr, &stringptr, 0);
-        setvertexmark(vertexloop, currentmarker);
+        setvertexmark(m, vertexloop, currentmarker);
       }
     } else {
       /* If no markers are specified in the file, they default to zero. */
-      setvertexmark(vertexloop, 0);
+      setvertexmark(m, vertexloop, 0);
     }
-    setvertextype(vertexloop, INPUTVERTEX);
+    setvertextype(m, vertexloop, INPUTVERTEX);
     /* Determine the smallest and largest x and y coordinates. */
     if (i == 0) {
       m->xmin = m->xmax = x;
@@ -14167,12 +14167,12 @@ int numberofpointattribs;
     }
     if (pointmarkerlist != (int *) NULL) {
       /* Read a vertex marker. */
-      setvertexmark(vertexloop, pointmarkerlist[i]);
+      setvertexmark(m, vertexloop, pointmarkerlist[i]);
     } else {
       /* If no markers are specified, they default to zero. */
-      setvertexmark(vertexloop, 0);
+      setvertexmark(m, vertexloop, 0);
     }
-    setvertextype(vertexloop, INPUTVERTEX);
+    setvertextype(m, vertexloop, INPUTVERTEX);
     /* Determine the smallest and largest x and y coordinates. */
     if (i == 0) {
       m->xmin = m->xmax = x;
@@ -14444,7 +14444,7 @@ char **argv;
   vertexnumber = b->firstnumber;
   vertexloop = vertextraverse(m);
   while (vertexloop != (vertex) NULL) {
-    if (!b->jettison || (vertextype(vertexloop) != UNDEADVERTEX)) {
+    if (!b->jettison || (vertextype(m, vertexloop) != UNDEADVERTEX)) {
 #ifdef TRILIBRARY
       /* X and y coordinates. */
       plist[coordindex++] = vertexloop[0];
@@ -14455,7 +14455,7 @@ char **argv;
       }
       if (!b->nobound) {
         /* Copy the boundary marker. */
-        pmlist[vertexnumber - b->firstnumber] = vertexmark(vertexloop);
+        pmlist[vertexnumber - b->firstnumber] = vertexmark(m, vertexloop);
       }
 #else /* not TRILIBRARY */
       /* Vertex number, x and y coordinates. */
@@ -14469,11 +14469,11 @@ char **argv;
         fprintf(outfile, "\n");
       } else {
         /* Write the boundary marker. */
-        fprintf(outfile, "    %d\n", vertexmark(vertexloop));
+        fprintf(outfile, "    %d\n", vertexmark(m, vertexloop));
       }
 #endif /* not TRILIBRARY */
 
-      setvertexmark(vertexloop, vertexnumber);
+      setvertexmark(m, vertexloop, vertexnumber);
       vertexnumber++;
     }
     vertexloop = vertextraverse(m);
@@ -14510,8 +14510,8 @@ struct behavior *b;
   vertexnumber = b->firstnumber;
   vertexloop = vertextraverse(m);
   while (vertexloop != (vertex) NULL) {
-    setvertexmark(vertexloop, vertexnumber);
-    if (!b->jettison || (vertextype(vertexloop) != UNDEADVERTEX)) {
+    setvertexmark(m, vertexloop, vertexnumber);
+    if (!b->jettison || (vertextype(m, vertexloop) != UNDEADVERTEX)) {
       vertexnumber++;
     }
     vertexloop = vertextraverse(m);
@@ -14612,40 +14612,40 @@ char **argv;
     apex(triangleloop, p3);
     if (b->order == 1) {
 #ifdef TRILIBRARY
-      tlist[vertexindex++] = vertexmark(p1);
-      tlist[vertexindex++] = vertexmark(p2);
-      tlist[vertexindex++] = vertexmark(p3);
+      tlist[vertexindex++] = vertexmark(m, p1);
+      tlist[vertexindex++] = vertexmark(m, p2);
+      tlist[vertexindex++] = vertexmark(m, p3);
 #else /* not TRILIBRARY */
       /* Triangle number, indices for three vertices. */
       fprintf(outfile, "%4ld    %4d  %4d  %4d", elementnumber,
-              vertexmark(p1), vertexmark(p2), vertexmark(p3));
+              vertexmark(m, p1), vertexmark(m, p2), vertexmark(m, p3));
 #endif /* not TRILIBRARY */
     } else {
       mid1 = (vertex) triangleloop.tri[m->highorderindex + 1];
       mid2 = (vertex) triangleloop.tri[m->highorderindex + 2];
       mid3 = (vertex) triangleloop.tri[m->highorderindex];
 #ifdef TRILIBRARY
-      tlist[vertexindex++] = vertexmark(p1);
-      tlist[vertexindex++] = vertexmark(p2);
-      tlist[vertexindex++] = vertexmark(p3);
-      tlist[vertexindex++] = vertexmark(mid1);
-      tlist[vertexindex++] = vertexmark(mid2);
-      tlist[vertexindex++] = vertexmark(mid3);
+      tlist[vertexindex++] = vertexmark(m, p1);
+      tlist[vertexindex++] = vertexmark(m, p2);
+      tlist[vertexindex++] = vertexmark(m, p3);
+      tlist[vertexindex++] = vertexmark(m, mid1);
+      tlist[vertexindex++] = vertexmark(m, mid2);
+      tlist[vertexindex++] = vertexmark(m, mid3);
 #else /* not TRILIBRARY */
       /* Triangle number, indices for six vertices. */
       fprintf(outfile, "%4ld    %4d  %4d  %4d  %4d  %4d  %4d", elementnumber,
-              vertexmark(p1), vertexmark(p2), vertexmark(p3), vertexmark(mid1),
-              vertexmark(mid2), vertexmark(mid3));
+              vertexmark(m, p1), vertexmark(m, p2), vertexmark(m, p3), vertexmark(m, mid1),
+              vertexmark(m, mid2), vertexmark(m, mid3));
 #endif /* not TRILIBRARY */
     }
 
 #ifdef TRILIBRARY
     for (i = 0; i < m->eextras; i++) {
-      talist[attribindex++] = elemattribute(triangleloop, i);
+      talist[attribindex++] = elemattribute(m, triangleloop, i);
     }
 #else /* not TRILIBRARY */
     for (i = 0; i < m->eextras; i++) {
-      fprintf(outfile, "  %.17g", elemattribute(triangleloop, i));
+      fprintf(outfile, "  %.17g", elemattribute(m, triangleloop, i));
     }
     fprintf(outfile, "\n");
 #endif /* not TRILIBRARY */
@@ -14757,8 +14757,8 @@ char **argv;
     sdest(subsegloop, endpoint2);
 #ifdef TRILIBRARY
     /* Copy indices of the segment's two endpoints. */
-    slist[index++] = vertexmark(endpoint1);
-    slist[index++] = vertexmark(endpoint2);
+    slist[index++] = vertexmark(m, endpoint1);
+    slist[index++] = vertexmark(m, endpoint2);
     if (!b->nobound) {
       /* Copy the boundary marker. */
       smlist[subsegnumber - b->firstnumber] = mark(subsegloop);
@@ -14767,10 +14767,10 @@ char **argv;
     /* Segment number, indices of its two endpoints, and possibly a marker. */
     if (b->nobound) {
       fprintf(outfile, "%4ld    %4d  %4d\n", subsegnumber,
-              vertexmark(endpoint1), vertexmark(endpoint2));
+              vertexmark(m, endpoint1), vertexmark(m, endpoint2));
     } else {
       fprintf(outfile, "%4ld    %4d  %4d    %4d\n", subsegnumber,
-              vertexmark(endpoint1), vertexmark(endpoint2), mark(subsegloop));
+              vertexmark(m, endpoint1), vertexmark(m, endpoint2), mark(subsegloop));
     }
 #endif /* not TRILIBRARY */
 
@@ -14900,14 +14900,14 @@ char **argv;
         org(triangleloop, p1);
         dest(triangleloop, p2);
 #ifdef TRILIBRARY
-        elist[index++] = vertexmark(p1);
-        elist[index++] = vertexmark(p2);
+        elist[index++] = vertexmark(m, p1);
+        elist[index++] = vertexmark(m, p2);
 #endif /* TRILIBRARY */
         if (b->nobound) {
 #ifndef TRILIBRARY
           /* Edge number, indices of two endpoints. */
           fprintf(outfile, "%4ld   %d  %d\n", edgenumber,
-                  vertexmark(p1), vertexmark(p2));
+                  vertexmark(m, p1), vertexmark(m, p2));
 #endif /* not TRILIBRARY */
         } else {
           /* Edge number, indices of two endpoints, and a boundary marker. */
@@ -14919,14 +14919,14 @@ char **argv;
               emlist[edgenumber - b->firstnumber] = 0;
 #else /* not TRILIBRARY */
               fprintf(outfile, "%4ld   %d  %d  %d\n", edgenumber,
-                      vertexmark(p1), vertexmark(p2), 0);
+                      vertexmark(m, p1), vertexmark(m, p2), 0);
 #endif /* not TRILIBRARY */
             } else {
 #ifdef TRILIBRARY
               emlist[edgenumber - b->firstnumber] = mark(checkmark);
 #else /* not TRILIBRARY */
               fprintf(outfile, "%4ld   %d  %d  %d\n", edgenumber,
-                      vertexmark(p1), vertexmark(p2), mark(checkmark));
+                      vertexmark(m, p1), vertexmark(m, p2), mark(checkmark));
 #endif /* not TRILIBRARY */
             }
           } else {
@@ -14934,7 +14934,7 @@ char **argv;
             emlist[edgenumber - b->firstnumber] = trisym.tri == m->dummytri;
 #else /* not TRILIBRARY */
             fprintf(outfile, "%4ld   %d  %d  %d\n", edgenumber,
-                    vertexmark(p1), vertexmark(p2), trisym.tri == m->dummytri);
+                    vertexmark(m, p1), vertexmark(m, p2), trisym.tri == m->dummytri);
 #endif /* not TRILIBRARY */
           }
         }
@@ -15337,7 +15337,7 @@ char **argv;
   traversalinit(&m->vertices);
   vertexloop = vertextraverse(m);
   while (vertexloop != (vertex) NULL) {
-    if (!b->jettison || (vertextype(vertexloop) != UNDEADVERTEX)) {
+    if (!b->jettison || (vertextype(m, vertexloop) != UNDEADVERTEX)) {
       /* The "0.0" is here because the OFF format uses 3D coordinates. */
       fprintf(outfile, " %.17g  %.17g  %.17g\n", vertexloop[0], vertexloop[1],
               0.0);
@@ -15354,8 +15354,8 @@ char **argv;
     dest(triangleloop, p2);
     apex(triangleloop, p3);
     /* The "3" means a three-vertex polygon. */
-    fprintf(outfile, " 3   %4d  %4d  %4d\n", vertexmark(p1) - b->firstnumber,
-            vertexmark(p2) - b->firstnumber, vertexmark(p3) - b->firstnumber);
+    fprintf(outfile, " 3   %4d  %4d  %4d\n", vertexmark(m, p1) - b->firstnumber,
+            vertexmark(m, p2) - b->firstnumber, vertexmark(m, p3) - b->firstnumber);
     triangleloop.tri = triangletraverse(m);
   }
   finishfile(outfile, argc, argv);


### PR DESCRIPTION
* Make sure all macros pass in all variables used (a `mesh*` type varaible (aka `m`) needs to be passed in for several)
* Rewrite macros as always inlined functions to ensure type correctness